### PR TITLE
Add option to specify width for thumbnail mode

### DIFF
--- a/docs/wss_tools/quip/usage_thumbs.rst
+++ b/docs/wss_tools/quip/usage_thumbs.rst
@@ -29,7 +29,7 @@ Fix the paths in XML file::
 
 Start QUIP (select optional arguments given in square brackets)::
 
-    $ quip operation_file_001.xml [-g +300+150] [--nocopy] [--loglevel=10]
+    $ quip operation_file_001.xml [--mosaic-thumb-size=100] [-g +300+150] [--nocopy] [--loglevel=10]
 
 Behind the scenes, QUIP resizes the images to smaller thumbnails using
 :func:`~wss_tools.quip.main.shrink_input_images` and save them


### PR DESCRIPTION
As requested by @Skyhawk172 

NOTE: For new width to take effect, it is important to `rm -r quipcache` first to remove previously generated thumbnails. QUIP was instructed to never remove files, so I did not add an option to clear cache.