### PR TITLE
Fix QUIP giving error when no --mosaic-thumb-size is given

### DIFF
--- a/wss_tools/quip/main.py
+++ b/wss_tools/quip/main.py
@@ -108,6 +108,8 @@ def main(args):
     if not nocopy:
         copy_ginga_files()
 
+    thumb_width = 100
+
     for i, a in enumerate(args):
         # Ignore any custom log file provided by user
         if a.startswith('--log='):
@@ -118,7 +120,7 @@ def main(args):
             try:
                 thumb_width = int(a.split('=')[1])
             except Exception:
-                thumb_width = 100
+                pass  # Use default
 
     # Extract info from input XML
     QUIP_DIRECTIVE = qio.input_xml(inputxml)


### PR DESCRIPTION
Follow up to #32 and a bug fix for 0.4.1. However, @Skyhawk172 does not yet need this as an immediate release, so this will be in `master` (dev) only until next release. In the meantime, `--mosaic-thumb-size` needs to be explicitly given when in `THUMBNAIL` operation mode.