### PR TITLE
Increase mosaic limit in SaveImage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 Python 2 is no longer supported.
 
+* Up the mosaic limit for saving using ``SaveImage``. [#41]
+
 0.5 (2018-02-14)
 ----------------
 

--- a/wss_tools/quip/config/plugin_SaveImage.cfg
+++ b/wss_tools/quip/config/plugin_SaveImage.cfg
@@ -11,3 +11,6 @@ include_chname = False
 
 # List all modified and unmodified images
 modified_only = False
+
+# Increase the max size of save-able mosaic.
+max_mosaic_size = 1e10


### PR DESCRIPTION
By default, `SaveImage` imposes a max size limit of 1e8 for any mosaic in Ginga. Anything larger will not be saved out. This PR ups the upper limit for QUIP to accommodate its use case.

cc @Skyhawk172 