### PR TITLE
Convenience tools for Segment ID

### DIFF
--- a/wss_tools/quip/main.py
+++ b/wss_tools/quip/main.py
@@ -58,7 +58,8 @@ def main(args):
 
     * ``--mosaic-thumb-size`` can be used to specify desired width in pixels
       for individual images to be mosaicked in ``THUMBNAIL`` mode.
-      If not given, the default width is 100 pixels.
+      If not given, the default width is 100 pixels, except for
+      Segment ID it's 256.
     * ``--nocopy`` can be used with QUIP to instruct
       it to *not* copy its Ginga files to user's HOME directory.
     * ``--log=filename``, if given in command line, will be ignored
@@ -159,7 +160,7 @@ def main(args):
     elif op_type == 'segment_id':
         cfgmode = 'mosaicmode'
         ginga_config_py_sfx = op_type
-        images = _segid_mosaics(images, outpath=tempdir)
+        images = _segid_mosaics(images, outpath=tempdir, sw_sca_size=256 )
 
     else:  # different kinds of analysis
         cfgmode = 'normalmode'
@@ -212,6 +213,10 @@ def get_ginga_plugins(op_type):
 
     if op_type == 'segment_id':
         local_plugins = []
+        # Add special plugin for segment ID annotations
+        global_plugins += [
+            Bunch(module='SegIDHelper', tab='SegIDHelper', workspace='left',
+              category='Custom', ptype='global', pfx=wss_pfx)]
     elif op_type == 'thumbnail':
         local_plugins = [
             Bunch(module='MosaicAuto', workspace='dialogs',
@@ -387,7 +392,7 @@ def shrink_input_images(images, outpath='', new_width=100, **kwargs):
     return outlist
 
 
-def _segid_mosaics(images, **kwargs):
+def _segid_mosaics(images, sw_sca_size=256, **kwargs):
     """Generate a scaled-down NIRCam mosaic for each exposure.
 
     The mosaics are not deleted on exit;
@@ -408,7 +413,7 @@ def _segid_mosaics(images, **kwargs):
 
     """
     from ..utils.mosaic import NircamMosaic
-    m = NircamMosaic()
+    m = NircamMosaic(sw_sca_size=sw_sca_size)
     return m.make_mosaic(images, **kwargs)
 
 

--- a/wss_tools/quip/main.py
+++ b/wss_tools/quip/main.py
@@ -160,7 +160,7 @@ def main(args):
     elif op_type == 'segment_id':
         cfgmode = 'mosaicmode'
         ginga_config_py_sfx = op_type
-        images = _segid_mosaics(images, outpath=tempdir, sw_sca_size=256 )
+        images = _segid_mosaics(images, outpath=tempdir, sw_sca_size=256)
 
     else:  # different kinds of analysis
         cfgmode = 'normalmode'
@@ -216,7 +216,7 @@ def get_ginga_plugins(op_type):
         # Add special plugin for segment ID annotations
         global_plugins += [
             Bunch(module='SegIDHelper', tab='SegIDHelper', workspace='left',
-              category='Custom', ptype='global', pfx=wss_pfx)]
+                  category='Custom', ptype='global', pfx=wss_pfx)]
     elif op_type == 'thumbnail':
         local_plugins = [
             Bunch(module='MosaicAuto', workspace='dialogs',

--- a/wss_tools/quip/plugins/SegIDHelper.py
+++ b/wss_tools/quip/plugins/SegIDHelper.py
@@ -3,9 +3,10 @@ from ginga.gw import Widgets
 
 import os.path
 
-# Plugin to draw helpful annotations for segment ID. 
+# Plugin to draw helpful annotations for segment ID.
 # based on Ginga example code MyGlobalPlugin.py
 # modified by Marshall Perrin.
+
 
 class SegIDHelper(GingaPlugin.GlobalPlugin):
 
@@ -23,13 +24,6 @@ class SegIDHelper(GingaPlugin.GlobalPlugin):
 
         self.dc = fv.getDrawClasses()
         self.canvas = self.dc.DrawingCanvas()
-
-        # Subscribe to some interesting callbacks that will inform us
-        # of channel events.  You may not need these depending on what
-        # your plugin does
-        #fv.set_callback('add-channel', self.add_channel)
-        #fv.set_callback('delete-channel', self.delete_channel)
-        #fv.set_callback('active-image', self.focus_cb)
 
     def build_gui(self, container):
         """
@@ -90,12 +84,6 @@ class SegIDHelper(GingaPlugin.GlobalPlugin):
 
         # Add our GUI to the container
         container.add_widget(top, stretch=1)
-        # NOTE: if you are building a GUI using a specific widget toolkit
-        # (e.g. Qt) GUI calls, you need to extract the widget or layout
-        # from the non-toolkit specific container wrapper and call on that
-        # to pack your widget, e.g.:
-        #cw = container.get_widget()
-        #cw.addWidget(widget, stretch=1)
 
     def get_channel_info(self, fitsimage):
         chname = self.fv.get_channelName(fitsimage)
@@ -108,8 +96,8 @@ class SegIDHelper(GingaPlugin.GlobalPlugin):
         # Update display in response to new image
         fitsimage = channel.fitsimage
 
-
-        # Ensure this plugin's canvas is added on top of the current image's display
+        # Ensure this plugin's canvas is added on top of
+        # the current image's display
         p_canvas = fitsimage.get_canvas()
         if not p_canvas.has_object(self.canvas):
             p_canvas.add(self.canvas, tag=self.layertag)
@@ -129,17 +117,16 @@ class SegIDHelper(GingaPlugin.GlobalPlugin):
         t1 = Text(50, 50, filename, color=color, fontsize=20, coord='window')
         self.canvas.add(t1)
 
+        # Hard coded locations for NIRCam SW SCAs.
+        # This will need updating if you change the mosaic settings.
 
-        # Hard coded locations for NIRCam SW SCAs. 
-        #This will need updating if you change the mosaic settings.
+        im_size = 256   # must match call to _segid_mosaics in QUIP main.py
 
-        im_size = 256 # must match call to _segid_mosaics in QUIP main.py
-
-        o = 20 # offset
-        sw_sep = 21
-        ab_gap = 150
-        bot = im_size-o
-        top = bot + im_size+sw_sep
+        o = 20            # offset of text relative to SCA
+        sw_sep = 21       # separation between SCAs in same module
+        ab_gap = 150      # separation between modules A and B
+        bot = im_size-o   # Y pos for bottom row
+        top = bot + im_size+sw_sep    # Y pos for top row
         SCA_info = {
                 'A1': [o, bot],
                 'A2': [o, top],
@@ -152,13 +139,16 @@ class SegIDHelper(GingaPlugin.GlobalPlugin):
                 }
 
         for scaname, location in SCA_info.items():
-            # Annotate text for each SCA. 
+            # Annotate text for each SCA.
 
-            # Repeated 2x for a hacky drop shadow effect, for better visibility across a wider range of stretches
-            t2s = Text(location[0]+1, location[1]-1, scaname, color='black', fontsize=18, coord='data')
+            # Repeated 2x for a hacky drop shadow effect,
+            # for better visibility across a wider range of stretches
+            t2s = Text(location[0]+1, location[1]-1, scaname,
+                       color='black', fontsize=18, coord='data')
             self.canvas.add(t2s)
 
-            t2 = Text(location[0], location[1], scaname, color='orange', fontsize=18, coord='data')
+            t2 = Text(location[0], location[1], scaname,
+                      color='orange', fontsize=18, coord='data')
             self.canvas.add(t2)
 
     def close(self):

--- a/wss_tools/quip/plugins/SegIDHelper.py
+++ b/wss_tools/quip/plugins/SegIDHelper.py
@@ -107,7 +107,8 @@ class SegIDHelper(GingaPlugin.GlobalPlugin):
         Text = self.canvas.get_draw_class('text')
 
         filename = os.path.basename(image.metadata['path'])
-        t1 = Text(50, 50, filename, color='yellow', fontsize=20, coord='window')
+        t1 = Text(50, 50, filename, color='yellow', fontsize=20,
+                  coord='window')
         self.canvas.add(t1)
 
         # Hard coded locations for NIRCam SW SCAs.

--- a/wss_tools/quip/plugins/SegIDHelper.py
+++ b/wss_tools/quip/plugins/SegIDHelper.py
@@ -85,11 +85,6 @@ class SegIDHelper(GingaPlugin.GlobalPlugin):
         # Add our GUI to the container
         container.add_widget(top, stretch=1)
 
-    def get_channel_info(self, fitsimage):
-        chname = self.fv.get_channelName(fitsimage)
-        chinfo = self.fv.get_channelInfo(chname)
-        return chinfo
-
     # CALLBACKS
 
     def redo(self, channel, image):
@@ -105,23 +100,20 @@ class SegIDHelper(GingaPlugin.GlobalPlugin):
         # auto zoom to fit
         fitsimage.zoom_fit()
 
-        # trash any prior annotations
+        # clean out any prior annotations
         self.canvas.delete_all_objects()
 
         # add new annotations
-
         Text = self.canvas.get_draw_class('text')
-        color = 'yellow'
 
         filename = os.path.basename(image.metadata['path'])
-        t1 = Text(50, 50, filename, color=color, fontsize=20, coord='window')
+        t1 = Text(50, 50, filename, color='yellow', fontsize=20, coord='window')
         self.canvas.add(t1)
 
         # Hard coded locations for NIRCam SW SCAs.
         # This will need updating if you change the mosaic settings.
 
         im_size = 256   # must match call to _segid_mosaics in QUIP main.py
-
         o = 20            # offset of text relative to SCA
         sw_sep = 21       # separation between SCAs in same module
         ab_gap = 150      # separation between modules A and B

--- a/wss_tools/quip/plugins/SegIDHelper.py
+++ b/wss_tools/quip/plugins/SegIDHelper.py
@@ -1,0 +1,173 @@
+from ginga import GingaPlugin
+from ginga.gw import Widgets
+
+import os.path
+
+# Plugin to draw helpful annotations for segment ID. 
+# based on Ginga example code MyGlobalPlugin.py
+# modified by Marshall Perrin.
+
+class SegIDHelper(GingaPlugin.GlobalPlugin):
+
+    def __init__(self, fv):
+        """
+        This method is called when the plugin is loaded for the  first
+        time.  ``fv`` is a reference to the Ginga (reference viewer) shell.
+
+        """
+        super(SegIDHelper, self).__init__(fv)
+
+        # init some stuff for drawing annotations
+
+        self.layertag = 'segidhelper-canvas'
+
+        self.dc = fv.getDrawClasses()
+        self.canvas = self.dc.DrawingCanvas()
+
+        # Subscribe to some interesting callbacks that will inform us
+        # of channel events.  You may not need these depending on what
+        # your plugin does
+        #fv.set_callback('add-channel', self.add_channel)
+        #fv.set_callback('delete-channel', self.delete_channel)
+        #fv.set_callback('active-image', self.focus_cb)
+
+    def build_gui(self, container):
+        """
+        This method is called when the plugin is invoked.  It builds the
+        GUI used by the plugin into the widget layout passed as
+        ``container``.
+        This method could be called several times if the plugin is opened
+        and closed.  The method may be omitted if there is no GUI for the
+        plugin.
+
+        This specific example uses the GUI widget set agnostic wrappers
+        to build the GUI, but you can also just as easily use explicit
+        toolkit calls here if you only want to support one widget set.
+        """
+        top = Widgets.VBox()
+        top.set_border_width(4)
+
+        # this is a little trick for making plugins that work either in
+        # a vertical or horizontal orientation.  It returns a box container,
+        # a scroll widget and an orientation ('vertical', 'horizontal')
+        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox.set_border_width(4)
+        vbox.set_spacing(2)
+
+        # Take a text widget to show some instructions
+        self.msgFont = self.fv.getFont("sansFont", 12)
+        tw = Widgets.TextArea(wrap=True, editable=False)
+        tw.set_font(self.msgFont)
+        self.tw = tw
+
+        # Frame for instructions and add the text widget with another
+        # blank widget to stretch as needed to fill emp
+        fr = Widgets.Frame("Status")
+        vbox2 = Widgets.VBox()
+        vbox2.add_widget(tw)
+        vbox2.add_widget(Widgets.Label(''), stretch=1)
+        fr.set_widget(vbox2)
+        vbox.add_widget(fr, stretch=0)
+
+        # Add a spacer to stretch the rest of the way to the end of the
+        # plugin space
+        spacer = Widgets.Label('')
+        vbox.add_widget(spacer, stretch=1)
+
+        # scroll bars will allow lots of content to be accessed
+        top.add_widget(sw, stretch=1)
+
+        # A button box that is always visible at the bottom
+        btns = Widgets.HBox()
+        btns.set_spacing(3)
+
+        # Add a close button for the convenience of the user
+        btn = Widgets.Button("Close")
+        btn.add_callback('activated', lambda w: self.close())
+        btns.add_widget(btn, stretch=0)
+        btns.add_widget(Widgets.Label(''), stretch=1)
+        top.add_widget(btns, stretch=0)
+
+        # Add our GUI to the container
+        container.add_widget(top, stretch=1)
+        # NOTE: if you are building a GUI using a specific widget toolkit
+        # (e.g. Qt) GUI calls, you need to extract the widget or layout
+        # from the non-toolkit specific container wrapper and call on that
+        # to pack your widget, e.g.:
+        #cw = container.get_widget()
+        #cw.addWidget(widget, stretch=1)
+
+    def get_channel_info(self, fitsimage):
+        chname = self.fv.get_channelName(fitsimage)
+        chinfo = self.fv.get_channelInfo(chname)
+        return chinfo
+
+    # CALLBACKS
+
+    def redo(self, channel, image):
+        # Update display in response to new image
+        fitsimage = channel.fitsimage
+
+
+        # Ensure this plugin's canvas is added on top of the current image's display
+        p_canvas = fitsimage.get_canvas()
+        if not p_canvas.has_object(self.canvas):
+            p_canvas.add(self.canvas, tag=self.layertag)
+
+        # auto zoom to fit
+        fitsimage.zoom_fit()
+
+        # trash any prior annotations
+        self.canvas.delete_all_objects()
+
+        # add new annotations
+
+        Text = self.canvas.get_draw_class('text')
+        color = 'yellow'
+
+        filename = os.path.basename(image.metadata['path'])
+        t1 = Text(50, 50, filename, color=color, fontsize=20, coord='window')
+        self.canvas.add(t1)
+
+
+        # Hard coded locations for NIRCam SW SCAs. 
+        #This will need updating if you change the mosaic settings.
+
+        im_size = 256 # must match call to _segid_mosaics in QUIP main.py
+
+        o = 20 # offset
+        sw_sep = 21
+        ab_gap = 150
+        bot = im_size-o
+        top = bot + im_size+sw_sep
+        SCA_info = {
+                'A1': [o, bot],
+                'A2': [o, top],
+                'A3': [o+im_size+sw_sep, bot],
+                'A4': [o+im_size+sw_sep, top],
+                'B1': [o+im_size*3+sw_sep*2+ab_gap, top],
+                'B2': [o+im_size*3+sw_sep*2+ab_gap, bot],
+                'B3': [o+im_size*2+sw_sep+ab_gap, top],
+                'B4': [o+im_size*2+sw_sep+ab_gap, bot],
+                }
+
+        for scaname, location in SCA_info.items():
+            # Annotate text for each SCA. 
+
+            # Repeated 2x for a hacky drop shadow effect, for better visibility across a wider range of stretches
+            t2s = Text(location[0]+1, location[1]-1, scaname, color='black', fontsize=18, coord='data')
+            self.canvas.add(t2s)
+
+            t2 = Text(location[0], location[1], scaname, color='orange', fontsize=18, coord='data')
+            self.canvas.add(t2)
+
+    def close(self):
+        self.fv.stop_global_plugin(str(self))
+        return True
+
+    def __str__(self):
+        """
+        This method should be provided and should return the lower case
+        name of the plugin.
+        """
+        return 'segidhelper'


### PR DESCRIPTION
This implements the suggestions in issue #46 . 

- New plugin `SegIDHelper` which annotates the NIRCam SCA labels onto the NIRCam mosaic image. It also shows the current filename too, in large & easy-to-read font. This is only loaded when `op_type='segment_id'`.
- Zoom-to-fit is automatically applied to each image in the channel, for instance when switching between images. Also only during segment ID. You can still zoom in more if desired in any given image; this just eases having the same zoom when blinking between different images in the channel. 
-  Not part of the plugin directly, but a semi-related change. I made the size of each NIRCam SW image slightly larger, 256 pixels rather than 100. The 100 is a decent choice for the ultra-large initial image mosaic, but we can use a less aggressive zoom setting for segment ID to maintain more detail. 


<img width="2090" alt="quip_with_labels_for_seg_id" src="https://user-images.githubusercontent.com/1151745/52304887-c084b580-2961-11e9-9a55-3e6af6510d28.png">
