### PR TITLE
Add QUIP operation file docs

### DIFF
--- a/docs/wss_tools/quip/index.rst
+++ b/docs/wss_tools/quip/index.rst
@@ -39,7 +39,7 @@ To start QUIP with a "QUIP Operation File" in the current working directory::
 
 .. note::
 
-   For help with generating an operation file, check out the `Jupyter notebook example <https://github.com/spacetelescope/wss_tools/tree/master/notebooks/quip_operation_file.ipynb>`_.
+    For help with generating an operation file, check out the `Jupyter notebook example <https://github.com/spacetelescope/wss_tools/tree/master/notebooks/quip_operation_file.ipynb>`_.
 
 
 During the development phase, sometimes unintentional bugs might cause Ginga

--- a/docs/wss_tools/quip/index.rst
+++ b/docs/wss_tools/quip/index.rst
@@ -37,6 +37,11 @@ To start QUIP with a "QUIP Operation File" in the current working directory::
 
     $ quip operation_file_001.xml
 
+.. note::
+
+   For help with generating an operation file, check out the `Jupyter notebook example <https://github.com/spacetelescope/wss_tools/tree/master/notebooks/quip_operation_file.ipynb>`_.
+
+
 During the development phase, sometimes unintentional bugs might cause Ginga
 to produce segmentation fault. When this happens, you can do the following
 using `GDB <https://www.gnu.org/software/gdb/>`_ to get the traceback and

--- a/notebooks/quip_operation_file.ipynb
+++ b/notebooks/quip_operation_file.ipynb
@@ -27,7 +27,7 @@
    },
    "outputs": [],
    "source": [
-    "input_dir = '/user/lchambers/OTECommSims/OTE01_reducedmosaic/images/'"
+    "input_dir = '/mypath/images/'"
    ]
   },
   {

--- a/notebooks/quip_operation_file.ipynb
+++ b/notebooks/quip_operation_file.ipynb
@@ -40,7 +40,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "files = glob.glob(input_dir + '*.fits')\n",
@@ -57,11 +59,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Define where the file will be saved (default is notebooks/ dir)\n",
-    "outdir =  os.getcwd()\n",
+    "# Define where the file will be saved\n",
+    "outdir =  'dir/to/save/opsfile'\n",
     "opsfile = os.path.join(outdir, 'quip_operation_file.xml')\n",
     "opsfile"
    ]
@@ -69,30 +73,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Write out the file\n",
-    "f = open(opsfile, 'w')\n",
-    "f.write('<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\\n')\n",
-    "f.write('<QUIP_OPERATION_FILE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" creator=\"WSS Executive\" time=\"16:22:40.093Z\" date=\"2017-06-14Z\" version=\"6.0.1\" operational=\"false\" xsi:noNamespaceSchemaLocation=\"/Users/lajoie/TEL/WSS-6.0.1/Software/schema/quip_operation_file.xsd\">\\n')\n",
-    "f.write('    <CORRECTION_ID>R2017061401</CORRECTION_ID>\\n')\n",
-    "f.write('    <OPERATION_TYPE>THUMBNAIL</OPERATION_TYPE>\\n')\n",
-    "f.write('    <IMAGES>\\n')\n",
+    "with open(opsfile, 'w') as f:\n",
+    "    f.write('<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\\n')\n",
+    "    f.write('<QUIP_OPERATION_FILE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" creator=\"WSS Executive\" time=\"16:22:40.093Z\" date=\"2017-06-14Z\" version=\"6.0.1\" operational=\"false\" xsi:noNamespaceSchemaLocation=\"/Users/lajoie/TEL/WSS-6.0.1/Software/schema/quip_operation_file.xsd\">\\n')\n",
+    "    f.write('    <CORRECTION_ID>R2017061401</CORRECTION_ID>\\n')\n",
+    "    f.write('    <OPERATION_TYPE>THUMBNAIL</OPERATION_TYPE>\\n')\n",
+    "    f.write('    <IMAGES>\\n')\n",
     "\n",
-    "for file_name in files:\n",
-    "    f.write(\"       <IMAGE_PATH>{:s}</IMAGE_PATH>\\n\".format(file_name))\n",
-    "    \n",
-    "f.write( '       </IMAGES>\\n'    )\n",
-    "f.write( '       <OUTPUT>\\n')\n",
-    "f.write( '           <OUTPUT_DIRECTORY>{:s}/quip/</OUTPUT_DIRECTORY>\\n'.format(outdir))\n",
-    "f.write( '           <LOG_FILE_PATH>{:s}/quip/R2017061401_quip_activity_log.xml</LOG_FILE_PATH>\\n'.format(outdir))\n",
-    "f.write( '           <OUT_FILE_PATH>{:s}/quip/R2017061401_quip_out.xml</OUT_FILE_PATH>\\n'.format(outdir))\n",
-    "f.write( '       </OUTPUT>\\n')\n",
+    "    for file_name in files:\n",
+    "        f.write(\"       <IMAGE_PATH>{:s}</IMAGE_PATH>\\n\".format(file_name))\n",
     "\n",
-    "f.write('</QUIP_OPERATION_FILE>\\n')\n",
+    "    f.write( '       </IMAGES>\\n'    )\n",
+    "    f.write( '       <OUTPUT>\\n')\n",
+    "    f.write( '           <OUTPUT_DIRECTORY>{:s}/quip/</OUTPUT_DIRECTORY>\\n'.format(outdir))\n",
+    "    f.write( '           <LOG_FILE_PATH>{:s}/quip/R2017061401_quip_activity_log.xml</LOG_FILE_PATH>\\n'.format(outdir))\n",
+    "    f.write( '           <OUT_FILE_PATH>{:s}/quip/R2017061401_quip_out.xml</OUT_FILE_PATH>\\n'.format(outdir))\n",
+    "    f.write( '       </OUTPUT>\\n')\n",
     "\n",
-    "f.close()"
+    "    f.write('</QUIP_OPERATION_FILE>\\n')"
    ]
   },
   {

--- a/notebooks/quip_operation_file.ipynb
+++ b/notebooks/quip_operation_file.ipynb
@@ -1,0 +1,151 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Point to a directory with the FITS images you want to load"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "input_dir = '/user/lchambers/OTECommSims/OTE01_reducedmosaic/images/'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Make a list that includes the full path to each of the FITS images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files = glob.glob(input_dir + '*.fits')\n",
+    "files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Generate an operation file with those images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define where the file will be saved (default is notebooks/ dir)\n",
+    "outdir =  os.getcwd()\n",
+    "opsfile = os.path.join(outdir, 'quip_operation_file.xml')\n",
+    "opsfile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Write out the file\n",
+    "f = open(opsfile, 'w')\n",
+    "f.write('<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\\n')\n",
+    "f.write('<QUIP_OPERATION_FILE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" creator=\"WSS Executive\" time=\"16:22:40.093Z\" date=\"2017-06-14Z\" version=\"6.0.1\" operational=\"false\" xsi:noNamespaceSchemaLocation=\"/Users/lajoie/TEL/WSS-6.0.1/Software/schema/quip_operation_file.xsd\">\\n')\n",
+    "f.write('    <CORRECTION_ID>R2017061401</CORRECTION_ID>\\n')\n",
+    "f.write('    <OPERATION_TYPE>THUMBNAIL</OPERATION_TYPE>\\n')\n",
+    "f.write('    <IMAGES>\\n')\n",
+    "\n",
+    "for file_name in files:\n",
+    "    f.write(\"       <IMAGE_PATH>{:s}</IMAGE_PATH>\\n\".format(file_name))\n",
+    "    \n",
+    "f.write( '       </IMAGES>\\n'    )\n",
+    "f.write( '       <OUTPUT>\\n')\n",
+    "f.write( '           <OUTPUT_DIRECTORY>{:s}/quip/</OUTPUT_DIRECTORY>\\n'.format(outdir))\n",
+    "f.write( '           <LOG_FILE_PATH>{:s}/quip/R2017061401_quip_activity_log.xml</LOG_FILE_PATH>\\n'.format(outdir))\n",
+    "f.write( '           <OUT_FILE_PATH>{:s}/quip/R2017061401_quip_out.xml</OUT_FILE_PATH>\\n'.format(outdir))\n",
+    "f.write( '       </OUTPUT>\\n')\n",
+    "\n",
+    "f.write('</QUIP_OPERATION_FILE>\\n')\n",
+    "\n",
+    "f.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Make the necessary `quip/` directory next to the operation file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "quip_dir = os.path.join(outdir, 'quip')\n",
+    "if not os.path.isdir(quip_dir): \n",
+    "    os.mkdir(quip_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Launch QUIP!\n",
+    "Now, you can run quip with:\n",
+    "```bash\n",
+    "quip quip_operation_file.xml\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
When we were getting set up with QUIP, both @shanosborne and I struggled with how to generate the operation file. Though there was an example XML schema provided, there weren't any docs we could find on how to generate one. This was rather frustrating, since the file is required to run QUIP out of the box.

I've modified a notebook here, which was first written by @Skyhawk172, to include basic code to generate a QUIP operation file from a directory of FITS images.

I figured I'd submit a PR to include it here, hoping it might be a useful resource for other new users. 

If this notebook doesn't really belong for some reason we haven't thought of, though, please let me know. Otherwise, please feel welcome to comment on the notebook itself.