### PR TITLE
New functionality to generate QUIP Operation File

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -146,7 +146,7 @@ CFG_OPTIONS = [
 ]
 
 
-class _Bootstrapper(object):
+class _Bootstrapper:
     """
     Bootstrapper implementation.  See ``use_astropy_helpers`` for parameter
     documentation.
@@ -846,7 +846,7 @@ def _next_version(version):
     return '{0}.{1}.{2}'.format(major, minor + 1, 0)
 
 
-class _DummyFile(object):
+class _DummyFile:
     """A noop writeable object."""
 
     errors = ''  # Required for Python 3.x

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,10 +46,15 @@ jobs:
       python setup.py build_docs -w
     displayName: 'Doc build'
 
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: 'htmlDocs'
-      targetPath: 'docs/_build/html'
+# DEV NOTE:
+# Not very useful like this because I have to sign in with Microsoft account,
+# download a ZIP file, unzip on local disk, and then only I can preview the
+# HTML pages. Was hoping for direct preview by clicking URL like CircleCI.
+#
+#  - task: PublishPipelineArtifact@0
+#    inputs:
+#      artifactName: 'htmlDocs'
+#      targetPath: 'docs/_build/html'
 
 - job: 'PEP8'
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,9 +42,14 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip setuptools
-      pip install numpy astropy matplotlib sphinx-rtd-theme sphinx-astropy
+      pip install numpy astropy matplotlib ginga stginga sphinx-rtd-theme sphinx-astropy
       python setup.py build_docs -w
     displayName: 'Doc build'
+
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'htmlDocs'
+      targetPath: 'docs/_build/html'
 
 - job: 'PEP8'
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,10 +24,27 @@ jobs:
       architecture: 'x64'
 
   - script: |
+      sudo apt-get install libxml2-utils
       python -m pip install --upgrade pip setuptools
       pip install numpy astropy pytest pytest-astropy
       python setup.py test
     displayName: 'Run tests'
+
+- job: 'Doc'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.x'
+      architecture: 'x64'
+
+  - script: |
+      python -m pip install --upgrade pip setuptools
+      pip install numpy astropy matplotlib sphinx-rtd-theme sphinx-astropy
+      python setup.py build_docs -w
+    displayName: 'Doc build'
 
 - job: 'PEP8'
   pool:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ except ImportError:
             sys.path.insert(1, a_h_path)
 
 # Load all of the global Astropy configuration
-from astropy_helpers.sphinx.conf import *
+from sphinx_astropy.conf import *
 
 # Get configuration information from setup.cfg
 from configparser import ConfigParser

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,6 +1,7 @@
 numpy>=1.13
 matplotlib
 Cython
+sphinx-rtd-theme
 sphinx-astropy
 astropy-helpers
 astropy

--- a/docs/wss_tools/quip/index.rst
+++ b/docs/wss_tools/quip/index.rst
@@ -123,6 +123,7 @@ Below are some examples for specific operation types:
 .. toctree::
    :maxdepth: 2
 
+   usage_opfile
    usage_simple
    usage_segid
    usage_thumbs

--- a/docs/wss_tools/quip/usage_opfile.rst
+++ b/docs/wss_tools/quip/usage_opfile.rst
@@ -1,0 +1,63 @@
+.. _quip-example-opfile-gen-1:
+
+Example: Generate QUIP Operation File
+=====================================
+
+When you are using QUIP outside of WEx, you might run into the situation
+where you wish to manually generate your own QUIP Operation File.
+
+The example below assumes the following directory structure with existing
+data files::
+
+    /my/path/
+        inputs/
+            image1.fits
+            image2.fits
+
+It also assumes the following desired outputs. The output *directory* will
+be automatically created by the example below, if it does not yet exist.
+While, the output *files* are to be created by QUIP itself, depending on what
+you actually do in your session (not by the example here)::
+
+    /my/path/
+        quip/
+            ginga.log
+            image1_quip.fits
+            R2017061401_quip_activity_log.xml
+            R2017061401_quip_out.xml
+
+To create a new QUIP Operation File in the same directory as input images, say,
+for the use case of :ref:`quip-example-simple-analysis-1`:
+
+>>> import glob
+>>> import os
+>>> from wss_tools.quip.qio import QUIPOpFile
+>>> opfile = QUIPOpFile('ANALYSIS', '/my/path/quip')
+>>> opfile.input_files = list(map(os.path.abspath, glob.iglob(
+...     '/my/path/inputs/image*.fits')))
+>>> opfile.input_files
+['/my/path/inputs/image1.fits',
+ '/my/path/inputs/image2.fits']
+>>> opfile.write_xml('/my/path/inputs/operation_file_001.xml')
+
+This would generate a QUIP Operation File that looks something like this::
+
+    <?xml version="1.0" ?>
+    <QUIP_OPERATION_FILE creator="QUIP" ...>
+        <CORRECTION_ID>R2017061401</CORRECTION_ID>
+        <OPERATION_TYPE>ANALYSIS</OPERATION_TYPE>
+        <IMAGES>
+            <IMAGE_PATH>/my/path/inputs/image1.fits</IMAGE_PATH>
+            <IMAGE_PATH>/my/path/inputs/image2.fits</IMAGE_PATH>
+        </IMAGES>
+        <OUTPUT>
+            <OUTPUT_DIRECTORY>/my/path/quip</OUTPUT_DIRECTORY>
+            <LOG_FILE_PATH>/my/path/quip/R2017061401_quip_activity_log.xml</LOG_FILE_PATH>
+            <OUT_FILE_PATH>/my/path/quip/R2017061401_quip_out.xml</OUT_FILE_PATH>
+        </OUTPUT>
+    </QUIP_OPERATION_FILE>
+
+Once you have the QUIP Operation File, you can proceed to use QUIP like this::
+
+    $ cd /my/path/inputs
+    $ quip operation_file_001.xml

--- a/wss_tools/quip/qio.py
+++ b/wss_tools/quip/qio.py
@@ -2,6 +2,7 @@
 
 # STDLIB
 import os
+import warnings
 import xml.etree.ElementTree as ET
 
 # THIRD-PARTY
@@ -11,9 +12,9 @@ from astropy.utils.xml.validate import validate_schema
 # LOCAL
 from ..utils.io import _etree_to_dict, _get_timestamp
 
-__all__ = ['input_xml', 'validate_input_xml', 'validate_output_out_xml',
-           'validate_output_log_xml', 'quip_out_dict', 'QUIPLog',
-           'QUIPLogEntry']
+__all__ = ['input_xml', 'validate_input_xml', 'QUIPOpFile',
+           'validate_output_out_xml', 'validate_output_log_xml',
+           'quip_out_dict', 'QUIPLog', 'QUIPLogEntry']
 
 
 def _validate_xml(filename, schema=''):
@@ -56,6 +57,130 @@ def validate_input_xml(filename):
     """Validate schema for QUIP Operation File (``quip_operation_file.xsd``).
     """
     return _validate_xml(filename, schema='quip_operation_file.xsd')
+
+
+class QUIPOpFile:
+    """Class to handle generation of QUIP Operation File.
+
+    Parameters
+    ----------
+    op_type : {'MIMF', 'SEGMENT_ID', 'THUMBNAIL'}
+        Operation type.
+
+    outdir : str
+        Output directory for the QUIP operation.
+        This is used only for the population of the ``OUTPUT`` fields
+        in the QUIP Operation File.
+
+    correction_id : str
+        Correction ID. Default value is arbitrary.
+
+    create_outdir : bool
+        Create the given ``outdir`` directory tree if it does not exist.
+
+    Raises
+    ------
+    ValueError
+        Invalid operation type.
+
+    Examples
+    --------
+    Create a QUIP Operation File from scratch:
+
+    >>> import glob
+    >>> import os
+    >>> from wss_tools.quip.qio import QUIPOpFile
+    >>> opfile = QUIPOpFile('THUMBNAIL', '/my/path/quip')
+    >>> opfile.input_files = list(map(os.path.abspath, glob.iglob('*.fits')))
+    >>> opfile.write_xml('/my/path/opsfile/operation_file_001.xml')
+
+    """
+    def __init__(self, op_type, outdir, correction_id='R2017061401',
+                 create_outdir=True):
+        valid_op_types = ('MIMF', 'SEGMENT_ID', 'THUMBNAIL')
+
+        if op_type not in valid_op_types:
+            raise ValueError(
+                'Valid operation types: {}'.format(','.join(valid_op_types)))
+
+        if create_outdir and not os.path.exists(outdir):
+            os.makedirs(outdir)
+
+        self.op_type = op_type
+        self.outdir = os.path.abspath(outdir)
+        self.correction_id = correction_id
+        self.creation_time = _get_timestamp()
+        self.quip_info = _get_quip_info()
+        self._files = []
+
+    @property
+    def input_files(self):
+        """List of input data filenames, with absolute paths."""
+        return self._files
+
+    @input_files.setter
+    def input_files(self, filelist):
+        if isinstance(filelist, str):
+            filelist = [filelist]
+        elif not isinstance(filelist, (list, tuple)):
+            raise ValueError('input_files must be a str or list of str')
+
+        self._files = []  # Reset
+
+        for filename in filelist:
+            # Too strict? Should we allow dummy filenames?
+            if os.path.isfile(filename):
+                self._files.append(filename)
+            else:
+                warnings.warn('Excluded {}; not a valid file'.format(filename),
+                              UserWarning)
+
+    def xml_dict(self):
+        """Create a dictionary that can be converted to
+        QUIP Operation File XML.
+
+        Returns
+        -------
+        out_dict : dict
+            Dictionary to be converted to XML by :meth:`write_xml`.
+
+        """
+        log_file_path = os.path.join(
+            self.outdir, '{}_quip_activity_log.xml'.format(self.correction_id))
+        out_file_path = os.path.join(
+            self.outdir, '{}_quip_out.xml'.format(self.correction_id))
+
+        d = {'@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+             '@xsi:noNamespaceSchemaLocation': 'quip_operation_file.xsd'}
+        d.update(self.creation_time)
+        d.update(self.quip_info)
+        d['CORRECTION_ID'] = self.correction_id
+        d['OPERATION_TYPE'] = self.op_type
+        d['IMAGES'] = {'IMAGE_PATH': self.input_files}
+        d['OUTPUT'] = {'OUTPUT_DIRECTORY': self.outdir,
+                       'LOG_FILE_PATH': log_file_path,
+                       'OUT_FILE_PATH': out_file_path}
+
+        return {'QUIP_OPERATION_FILE': d}
+
+    def write_xml(self, filename):
+        """Write the QUIP Operation File XML file.
+        This is really just a convenience method that calls
+        :func:`~wss_tools.utils.io.output_xml`.
+
+        Parameters
+        ----------
+        filename : str
+            Output XML file.
+
+        Raises
+        ------
+        OSError
+            Output file exists.
+
+        """
+        from ..utils.io import output_xml
+        output_xml(self.xml_dict(), filename)
 
 
 # -------------- #

--- a/wss_tools/quip/qio.py
+++ b/wss_tools/quip/qio.py
@@ -106,7 +106,7 @@ def quip_out_dict(images=[]):
     return {'QUIP_OUT': d}
 
 
-class QUIPLog(object):
+class QUIPLog:
     """Class to handle QUIP actions to document in log file
     and image history.
 
@@ -159,7 +159,7 @@ class QUIPLog(object):
         return {'QUIP_ACTIVITY_LOG': d}
 
 
-class QUIPLogEntry(object):
+class QUIPLogEntry:
     """Class to handle each log entry for `QUIPLog`.
 
     Parameters

--- a/wss_tools/tests/test_qio.py
+++ b/wss_tools/tests/test_qio.py
@@ -1,0 +1,43 @@
+import glob
+import os
+
+from wss_tools.quip import qio
+
+
+def test_opfile_gen(tmpdir):
+    """Test QUIP Operation File generator."""
+    optype = 'MIMF'
+    outdir = '/dummy/path'
+    imname = 'dummy.fits'
+    dummy_fits = tmpdir.join(imname)  # noqa
+    dummy_fits.write('content')
+    opfilename = os.path.join(tmpdir.strpath, 'operation_file_001.xml')
+    opfile = qio.QUIPOpFile(optype, outdir, create_outdir=False)
+    opfile.input_files = list(map(os.path.abspath, glob.iglob(
+        os.path.join(tmpdir.strpath, '*.fits'))))
+
+    assert len(opfile.input_files) == 1
+    assert opfile.input_files[0].endswith(imname)
+
+    opfile.write_xml(opfilename)
+
+    # Make sure it round-trips and check the important stuff
+    qio.validate_input_xml(opfilename)
+    opdict = qio.input_xml(opfilename)
+    imlist = opdict['IMAGES']['IMAGE_PATH']
+    assert len(imlist) == 1
+    assert imlist[0].endswith(imname)
+    assert opdict['OPERATION_TYPE'] == optype
+    assert opdict['OUTPUT']['OUTPUT_DIRECTORY'] == outdir
+    assert (opdict['OUTPUT']['LOG_FILE_PATH'] ==
+            os.path.join(outdir, 'R2017061401_quip_activity_log.xml'))
+    assert (opdict['OUTPUT']['OUT_FILE_PATH'] ==
+            os.path.join(outdir, 'R2017061401_quip_out.xml'))
+    assert opdict['@creator'] == 'QUIP'
+
+
+def test_get_quip_info():
+    quip_info = qio._get_quip_info()
+    assert quip_info['@creator'] == 'QUIP'
+    assert quip_info['@operational'] == 'false'
+    assert isinstance(quip_info['@version'], str)

--- a/wss_tools/utils/mosaic.py
+++ b/wss_tools/utils/mosaic.py
@@ -13,7 +13,7 @@ from scipy.ndimage.interpolation import zoom
 __all__ = ['NircamMosaic']
 
 
-class NircamMosaic(object):
+class NircamMosaic:
     """
     Class to handle NIRCAM mosaic.
 


### PR DESCRIPTION
Fix #50 

Close #49 

Example content of the generated QUIP Operation File:

```xml
<?xml version="1.0" ?>
<QUIP_OPERATION_FILE creator="QUIP" date="2019-03-13Z" operational="false" time="18:00:17.508383Z" version="1.0.1.dev346" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="quip_operation_file.xsd">
    <CORRECTION_ID>R2017061401</CORRECTION_ID>
    <OPERATION_TYPE>MIMF</OPERATION_TYPE>
    <IMAGES>
        <IMAGE_PATH>/my/path/inputs/ball_fqt_image001.fits</IMAGE_PATH>
        <IMAGE_PATH>/my/path/inputs/ball_fqt_image002.fits</IMAGE_PATH>
    </IMAGES>
    <OUTPUT>
        <OUTPUT_DIRECTORY>/my/path/quip</OUTPUT_DIRECTORY>
        <LOG_FILE_PATH>/my/path/quip/R2017061401_quip_activity_log.xml</LOG_FILE_PATH>
        <OUT_FILE_PATH>/my/path/quip/R2017061401_quip_out.xml</OUT_FILE_PATH>
    </OUTPUT>
</QUIP_OPERATION_FILE>
```