### PR TITLE
Use RTD PR builder

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# Set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  system_packages: true
+  install:
+    - requirements: docs/rtd-pip-requirements
+    - method: setuptools
+      path: .
+
+submodules:
+  include: all
+
+# Don't build any extra formats
+formats: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,32 +30,6 @@ jobs:
       python setup.py test
     displayName: 'Run tests'
 
-- job: 'Doc'
-  pool:
-    vmImage: 'Ubuntu-16.04'
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.x'
-      architecture: 'x64'
-
-  - script: |
-      python -m pip install --upgrade pip setuptools
-      pip install numpy astropy matplotlib ginga stginga sphinx-rtd-theme sphinx-astropy
-      python setup.py build_docs -w
-    displayName: 'Doc build'
-
-# DEV NOTE:
-# Not very useful like this because I have to sign in with Microsoft account,
-# download a ZIP file, unzip on local disk, and then only I can preview the
-# HTML pages. Was hoping for direct preview by clicking URL like CircleCI.
-#
-#  - task: PublishPipelineArtifact@0
-#    inputs:
-#      artifactName: 'htmlDocs'
-#      targetPath: 'docs/_build/html'
-
 - job: 'PEP8'
   pool:
     vmImage: 'Ubuntu-16.04'

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -3,7 +3,6 @@ matplotlib
 Cython
 sphinx-rtd-theme
 sphinx-astropy
-astropy-helpers
 astropy
 ginga
 stginga


### PR DESCRIPTION
Use RTD PR builder. Remove documentation build job from Azure because it is no longer needed. For RTD PR builder to work, need to use its v2 YAML.

Azure failure reported upstream at https://developercommunity.visualstudio.com/content/problem/726580/sudo-apt-get-install-libxml2-utils-failed-on-ubunt.html