### PR TITLE
MNT: Fix CLI entry point

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,5 +55,6 @@ docs =
     ginga
     stginga
 
-[entry_points]
-quip = wss_tools.quip.main:_main
+[options.entry_points]
+console_scripts =
+    quip = wss_tools.quip.main:_main


### PR DESCRIPTION
An oversight from #65 . This adds the `quip` CLI command back.