### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [tool:pytest]
+addopts = --doctest-ignore-import-errors
 minversion = 3.1
 testpaths = "wss_tools" "docs"
 norecursedirs = build docs/_build


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.