### PR TITLE
ENH: Multiprocessing for THUMBNAIL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 1.2 (unreleased)
 ----------------
 
+* Added ``--n-cores`` option for multiprocessing in downsampling images
+  in ``THUMBNAIL`` mode. [#72]
+
 1.1 (2020-02-03)
 ----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 * Added ``--n-cores`` option for multiprocessing in downsampling images
   in ``THUMBNAIL`` mode. [#72]
+* Default size of THUMBNAIL images has increased from 100 to 500. [#72]
 
 1.1 (2020-02-03)
 ----------------

--- a/wss_tools/quip/main.py
+++ b/wss_tools/quip/main.py
@@ -113,7 +113,7 @@ def main(args):
         copy_ginga_files()
 
     thumb_width = 500
-    n_cores = multiprocessing.cpu_count()
+    n_cores = None
 
     for i, a in enumerate(args):
         # Ignore any custom log file provided by user
@@ -167,6 +167,10 @@ def main(args):
         with fits.open(images[0]) as pf:
             if sci_ext not in pf:
                 sci_ext = ('IMAGE', 1)
+
+        # Auto guess the number of CPU cores needed.
+        if n_cores is None:
+            n_cores = min(multiprocessing.cpu_count(), len(images))
 
         images = shrink_input_images(
             images, ext=sci_ext, new_width=thumb_width, n_cores=n_cores,


### PR DESCRIPTION
Enable multiprocessing for downsampling images in THUMBNAIL mode. I checked that output images did not change at all (which is good) using `fitsdiff`. Also changed the default output dimension from 100 to 500 as @Skyhawk172 suggested.

Some timing:
```python
In [1]: import glob

In [2]: images = glob.glob('*.fits')

In [3]: len(images)
Out[3]: 10

In [4]: from wss_tools.quip.main import  shrink_input_images

In [5]: %time out = shrink_input_images(images, ext=('SCI', 1), new_width=500, outpath='ztmp1', n_cores=1)  # No multiprocessing
CPU times: user 1.38 s, sys: 173 ms, total: 1.55 s
Wall time: 1.58 s

In [6]: %time out = shrink_input_images(images, ext=('SCI', 1), new_width=500, outpath='ztmp2', n_cores=10)
CPU times: user 3.55 ms, sys: 23.4 ms, total: 26.9 ms
Wall time: 297 ms
```