### PR TITLE
MNT: Update astropy default branch

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -89,7 +89,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libxml2-utils
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install git+https://github.com/astropy/astropy.git@master#egg=astropy
+        python -m pip install git+https://github.com/astropy/astropy.git@main#egg=astropy
         python -m pip install git+https://github.com/ejeschke/ginga.git@master#egg=ginga
         python -m pip install git+https://github.com/spacetelescope/stginga.git@master#egg=stginga
         python -m pip install -e .[test]


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to because `astropy` has changed its default branch! You can report issues to @pllim.