### PR TITLE
MNT: Remove defunct help text area and use button

### DIFF
--- a/wss_tools/quip/plugins/SaveQUIP.py
+++ b/wss_tools/quip/plugins/SaveQUIP.py
@@ -56,15 +56,6 @@ class SaveQUIP(SaveImageParent):
 
         vbox, sw, orientation = Widgets.get_oriented_box(container)
 
-        msgFont = self.fv.getFont('sansFont', 12)
-        tw = Widgets.TextArea(wrap=True, editable=False)
-        tw.set_font(msgFont)
-        self.tw = tw
-
-        fr = Widgets.Expander('Instructions')
-        fr.set_widget(tw)
-        container.add_widget(fr, stretch=0)
-
         captions = (('Channel:', 'label', 'Channel Name', 'combobox',
                      'Modified only', 'checkbutton'), )
         w, b = Widgets.build_info(captions, orientation=orientation)
@@ -130,6 +121,9 @@ class SaveQUIP(SaveImageParent):
 
         btn = Widgets.Button('Close')
         btn.add_callback('activated', lambda w: self.close())
+        btns.add_widget(btn, stretch=0)
+        btn = Widgets.Button("Help")
+        btn.add_callback('activated', lambda w: self.help())
         btns.add_widget(btn, stretch=0)
         btns.add_widget(Widgets.Label(''), stretch=1)
         container.add_widget(btns, stretch=0)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/wss_tools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to remove defunct usage of Help text area and add the Help button like upstream in Ginga. No change in functionality of the plugin.

See https://github.com/ejeschke/ginga/issues/867#issuecomment-854220716