### PR TITLE
MNT: Stop using enable_deprecations_as_exceptions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,12 +14,6 @@ try:
 except ImportError:
     version = 'unknown'
 
-from astropy.tests.helper import enable_deprecations_as_exceptions
-
-# Uncomment the following line to treat all DeprecationWarnings as
-# exceptions
-enable_deprecations_as_exceptions()
-
 # Uncomment and customize the following lines to add/remove entries from
 # the list of packages for which version numbers are displayed when running
 # the tests. Making it pass for KeyError is essential in some cases when

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,10 @@ testpaths = "wss_tools" "docs"
 norecursedirs = build docs/_build
 astropy_header = true
 xfail_strict = true
+filterwarnings =
+    error
+    ignore:numpy.ufunc size changed:RuntimeWarning
+    ignore:numpy.ndarray size changed:RuntimeWarning
 
 [metadata]
 name = wss_tools


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/wss_tools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .

Also turns all unhandled warnings into exceptions.