### PR TITLE
Suppress FITSFixedWarning from newer astropy

### DIFF
--- a/wss_tools/quip/main.py
+++ b/wss_tools/quip/main.py
@@ -12,12 +12,14 @@ import os
 import platform
 import shutil
 import sys
+import warnings
 from functools import partial
 
 # THIRD-PARTY
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_filenames
 from astropy.utils.introspection import minversion
+from astropy.wcs import FITSFixedWarning
 
 # GINGA and STGINGA
 from ginga.rv import main as gmain
@@ -33,6 +35,9 @@ try:
     logging.lastResort = None
 except AttributeError:
     pass
+
+# Supress warning from astropy.wcs
+warnings.filterwarnings('ignore', category=FITSFixedWarning)
 
 __all__ = ['main', 'get_ginga_plugins', 'copy_ginga_files', 'set_ginga_config',
            'shrink_input_images']


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/wss_tools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

Not sure when it started but now when you do things like background subtraction with the plugin, you might see a `FITSFixedWarning` emitted on the terminal (something about `datfix` and MJDOBS for the test data that I have at hand). If I remember correctly, any terminal output would crash the Java version of WEX (you can confirm with Trey), so here I suppress the warning on the terminal.

@obi-wan76 , if you are not the person to review this, please tag your colleague that should. Thanks!

xref ejeschke/ginga#954