### PR TITLE
Recenter images if needed for wavefront maintenance

### DIFF
--- a/wss_tools/quip/main.py
+++ b/wss_tools/quip/main.py
@@ -27,6 +27,8 @@ from ginga.misc.Bunch import Bunch
 
 # LOCAL
 from . import qio
+from ..utils.recenter import recenter
+from ..utils.io import output_xml
 
 # Suppress logging "no handlers" message from Ginga
 import logging
@@ -197,24 +199,31 @@ def main(args):
         cfgmode = 'normalmode'
         ginga_config_py_sfx = cfgmode
 
-    # Add custom plugins.
-    # NOTE: There was a bug with setting this in ginga_config.py,
-    #       so we do this here instead.
-    global_plugins, local_plugins = get_ginga_plugins(ginga_config_py_sfx)
-    gmain.plugins += global_plugins
-    gmain.plugins += local_plugins
+    # Wavefront Maintenance will trigger QUIP Automatic Mode run a utility to recenter
+    # the images if needed and not launch ginga
+    if op_type == 'wavefront_maintenance':
+        output_images = recenter(images, QUIP_DIRECTIVE['OUTPUT']['OUTPUT_DIRECTORY'], doplot=False)
+        quipout = QUIP_DIRECTIVE['OUTPUT']['OUT_FILE_PATH']
+        output_xml(qio.quip_out_dict(output_images), quipout)
+    else:
+        # Add custom plugins.
+        # NOTE: There was a bug with setting this in ginga_config.py,
+        #       so we do this here instead.
+        global_plugins, local_plugins = get_ginga_plugins(ginga_config_py_sfx)
+        gmain.plugins += global_plugins
+        gmain.plugins += local_plugins
 
-    # Set Ginga config file(s)
-    set_ginga_config(mode=cfgmode, gcfg_suffix=ginga_config_py_sfx)
+        # Set Ginga config file(s)
+        set_ginga_config(mode=cfgmode, gcfg_suffix=ginga_config_py_sfx)
 
-    # Auto start core global plugins
-    for gplgname in ('ChangeHistory', ):
-        gplg = _locate_plugin(gmain.plugins, gplgname)
-        gplg.start = True
+        # Auto start core global plugins
+        for gplgname in ('ChangeHistory', ):
+            gplg = _locate_plugin(gmain.plugins, gplgname)
+            gplg.start = True
 
-    # Start Ginga
-    sys_args = ['ginga', f'--log={gingalog}'] + args + images
-    gmain.reference_viewer(sys_args)
+        # Start Ginga
+        sys_args = ['ginga', f'--log={gingalog}'] + args + images
+        gmain.reference_viewer(sys_args)
 
 
 def get_ginga_plugins(op_type):

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -1,0 +1,101 @@
+''' Module to recenter images '''
+import os
+from astropy.io import fits
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import ndimage
+
+
+def rebin(arr, new_shape):
+    '''
+    Rebin 2D array arr to shape new_shape by averaging
+    :param arr:
+    :param new_shape:
+    :return: newarr - new array
+    '''
+    shape = (new_shape[0], arr.shape[0] // new_shape[0],
+             new_shape[1], arr.shape[1] // new_shape[1])
+    newarr = np.nanmedian(np.nanmedian(arr.reshape(shape), axis=-1), axis=1)
+
+    return newarr
+
+
+def recenter(images, outputdir, doplot=False):
+    '''
+    Recenter images to NRCA3 FP3 (464, 1412)
+    :param images:
+    :param outputdir:
+    :param doplot:
+    :return: List of output_images that have been recentered
+    '''
+    output_images = []
+    for im_fn in images:
+        # Open fits
+        hdul = fits.open(im_fn)
+        data = hdul[1].data
+
+        # Rebin image with very big pixels to find the approximate location
+        size = 32
+        rebindata = rebin(data, [size, size])
+
+        # Remove background
+        rebindata -= np.median(rebindata)
+
+        # Find the center of mass and cut a box around: we should see the whole PSF with about 1-2 PSF wide margins
+        com = ndimage.center_of_mass(rebindata)
+        subdata = data[int((com[0] - 1.5) * 2048 / size):int((com[0] + 2.5) * 2048 / size),
+                    int((com[1] - 1.5) * 2048 / size):int((com[1] + 2.5) * 2048 / size)]
+
+        # Rebin again
+        rebinsubdata = rebin(subdata, [size, size])
+
+        # Remove background
+        rebinsubdata -= np.median(rebinsubdata)
+
+        # Find the center of mass and cut a box around: we should see the inside of the PSF
+        subdatacom = ndimage.center_of_mass(rebinsubdata)
+        subdata2 = subdata[int((subdatacom[0] - .5) * 2048 / size * 4 / size):int((subdatacom[0] + 1.5) * 2048 / size * 4 / size),
+                       int((subdatacom[1] - .5) * 2048 / size * 4 / size):int((subdatacom[1] + 1.5) * 2048 / size * 4 / size)]
+
+        # Find the center of mass
+        com2 = ndimage.center_of_mass(subdata2)
+
+        # "Recenter" the image to 464, 1412 instead to match the WAS expectations
+        xcpsf = com2[0] + int((subdatacom[0] - .5) * 2048 / size * 4 / size) + int((com[0] - 1.5) * 2048 / size)
+        ycpsf = com2[1] + int((subdatacom[1] - .5) * 2048 / size * 4 / size) + int((com[1] - 1.5) * 2048 / size)
+        offsetdata = np.roll(data, (464 - int(ycpsf), 1412 - int(xcpsf)), axis=(1, 0))
+
+        # Save back image into file
+        if abs(464 - ycpsf) > 10 or abs(1412 - xcpsf) > 10:
+            # Do the same for the ERR and the DQ
+            hdul[2].data = np.roll(hdul[2].data, (464 - int(ycpsf), 1412 - int(xcpsf)), axis=(1, 0))
+            hdul[3].data = np.roll(hdul[3].data, (464 - int(ycpsf), 1412 - int(xcpsf)), axis=(1, 0))
+            hdul[1].data = offsetdata
+            filename = os.path.basename(im_fn).replace('.fits', '_recenter.fits')
+            hdul.writeto(os.path.join(outputdir, filename), overwrite=True)
+            output_images.append(os.path.join(outputdir, filename))
+        else :
+            output_images.append(im_fn)
+
+        # Plot
+
+        fig, ((ax1, ax2), (ax3, ax4), (ax5, ax6)) = plt.subplots(3, 2, figsize=(12, 9))
+        fig.tight_layout(pad=.3)
+        ax1.imshow(data, origin='lower')
+        ax2.imshow(rebindata, origin='lower')
+
+        ax3.imshow(subdata, origin='lower')
+        ax4.imshow(rebinsubdata, origin='lower')
+
+        ax5.imshow(subdata2, origin='lower')
+        ax5.plot([com2[1], com2[1]], [0, 2048/size*4/size*2-1], 'r')
+        ax5.plot([0, 2048/size*4/size*2-1], [com2[0], com2[0]], 'r')
+
+        ax6.imshow(offsetdata, origin='lower')
+        ax6.plot([464, 464], [0, 2047], 'r')
+        ax6.plot([0, 2047], [1412, 1412], 'r')
+        if doplot:
+            plt.show()
+        else:
+            plt.savefig(os.path.join(outputdir,'plot.png'))
+    return output_images


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/wss_tools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
Updates to QUIP to support routine wavefront maintenance.  Some of the routine observations have shown that we may need to recenter the image since the WAS is particular about the centroid of the image to fall on a XY of NRCA3 FP3 (464, 1412).  So now if QUIP is run with WAVEFRONT_MAINTENANCE operation then it will invoke the recenter function to do some batch processing and update the quip_out.xml if the centroid was offset by 10px in X or Y.  

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #93 
