### PR TITLE
Recenter 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 1.3 (unreleased)
 ----------------
+* Recenter images if necessary for routine wavefront maintenance. [#93]
 
 1.2 (2021-06-11)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.3 (unreleased)
 ----------------
-* Recenter images if necessary for routine wavefront maintenance. [#93]
+
+* Recenter images if necessary for routine wavefront maintenance. [#95]
 
 1.2 (2021-06-11)
 ----------------

--- a/docs/wss_tools/ref_api.rst
+++ b/docs/wss_tools/ref_api.rst
@@ -12,3 +12,6 @@ References/API
 
 .. automodapi:: wss_tools.utils.mosaic
   :no-inheritance-diagram:
+
+.. automodapi:: wss_tools.utils.recenter
+  :no-inheritance-diagram:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     astropy>=3
     ginga>=2.7
     stginga>=1.0
+    matplotlib
 python_requires = >=3.7
 
 [options.package_data]

--- a/wss_tools/quip/main.py
+++ b/wss_tools/quip/main.py
@@ -174,7 +174,7 @@ def main(args):
         quipout = QUIP_DIRECTIVE['OUTPUT']['OUT_FILE_PATH']
         output_xml(qio.quip_out_dict(output_images), quipout)
         return
-    if op_type == 'thumbnail':
+    elif op_type == 'thumbnail':
         cfgmode = 'mosaicmode'
         ginga_config_py_sfx = op_type
         sci_ext = ('SCI', 1)

--- a/wss_tools/quip/main.py
+++ b/wss_tools/quip/main.py
@@ -199,10 +199,12 @@ def main(args):
         cfgmode = 'normalmode'
         ginga_config_py_sfx = cfgmode
 
-    # Wavefront Maintenance will trigger QUIP Automatic Mode run a utility to recenter
-    # the images if needed and not launch ginga
+    # Wavefront Maintenance will trigger QUIP Automatic Mode run a utility to
+    # recenter the images if needed and not launch ginga
     if op_type == 'wavefront_maintenance':
-        output_images = recenter(images, QUIP_DIRECTIVE['OUTPUT']['OUTPUT_DIRECTORY'], doplot=False)
+        output_images = recenter(images,
+                                 QUIP_DIRECTIVE['OUTPUT']['OUTPUT_DIRECTORY'],
+                                 doplot=False)
         quipout = QUIP_DIRECTIVE['OUTPUT']['OUT_FILE_PATH']
         output_xml(qio.quip_out_dict(output_images), quipout)
     else:

--- a/wss_tools/quip/main.py
+++ b/wss_tools/quip/main.py
@@ -27,6 +27,8 @@ from ginga.misc.Bunch import Bunch
 
 # LOCAL
 from . import qio
+from ..utils.recenter import recenter
+from ..utils.io import output_xml
 
 # Suppress logging "no handlers" message from Ginga
 import logging
@@ -197,24 +199,31 @@ def main(args):
         cfgmode = 'normalmode'
         ginga_config_py_sfx = cfgmode
 
-    # Add custom plugins.
-    # NOTE: There was a bug with setting this in ginga_config.py,
-    #       so we do this here instead.
-    global_plugins, local_plugins = get_ginga_plugins(ginga_config_py_sfx)
-    gmain.plugins += global_plugins
-    gmain.plugins += local_plugins
+    # Wavefront Maintenance will trigger QUIP Automatic Mode run a utility to recenter
+    # the images if needed and not launch ginga
+    if op_type == 'wavefront_maintenance':
+        output_images = recenter(images, QUIP_DIRECTIVE['OUTPUT']['OUTPUT_DIRECTORY'], doplot=False)
+        quipout = QUIP_DIRECTIVE['OUTPUT']['OUT_FILE_PATH']
+        output_xml(qio.quip_out_dict(output_images), quipout)
+    else:
+        # Add custom plugins.
+        # NOTE: There was a bug with setting this in ginga_config.py,
+        #       so we do this here instead.
+        global_plugins, local_plugins = get_ginga_plugins(ginga_config_py_sfx)
+        gmain.plugins += global_plugins
+        gmain.plugins += local_plugins
 
-    # Set Ginga config file(s)
-    set_ginga_config(mode=cfgmode, gcfg_suffix=ginga_config_py_sfx)
+        # Set Ginga config file(s)
+        set_ginga_config(mode=cfgmode, gcfg_suffix=ginga_config_py_sfx)
 
-    # Auto start core global plugins
-    for gplgname in ('ChangeHistory', ):
-        gplg = _locate_plugin(gmain.plugins, gplgname)
-        gplg.start = True
+        # Auto start core global plugins
+        for gplgname in ('ChangeHistory', ):
+            gplg = _locate_plugin(gmain.plugins, gplgname)
+            gplg.start = True
 
-    # Start Ginga
-    sys_args = ['ginga', f'--log={gingalog}'] + args + images
-    gmain.reference_viewer(sys_args)
+        # Start Ginga
+        sys_args = ['ginga', f'--log={gingalog}'] + args + images
+        gmain.reference_viewer(sys_args)
 
 
 def get_ginga_plugins(op_type):

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -10,7 +10,7 @@ __all__ = ['recenter']
 
 
 def recenter(images, outputdir, doplot=False):
-    ''' Recenter images based on NIRCam XY (464,1412) if offset > 10px
+    '''Recenter images based on NIRCam XY (464,1412) if offset > 10px
     Parameters
     ----------
     images: List

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -65,11 +65,10 @@ def recenter(images, outputdir, doplot=False):
         margin_right2 = 1.5
         margin_bottom2 = 0.5
         margin_top2 = 1.5
-        subdata2 = \
-            subdata[int((com1[0] - margin_left2) * imsize / size * 4 / size):
-                    int((com1[0] + margin_right2) * imsize / size * 4 / size),
-                    int((com1[1] - margin_bottom2) * imsize / size * 4 / size):
-                    int((com1[1] + margin_top2) * imsize / size * 4 / size)]
+        subdata2 = subdata[int((com1[0] - margin_left2) * imsize / size * 4 / size):
+                           int((com1[0] + margin_right2) * imsize / size * 4 / size),
+                           int((com1[1] - margin_bottom2) * imsize / size * 4 / size):
+                           int((com1[1] + margin_top2) * imsize / size * 4 / size)]
 
         # Find the center of mass
         com2 = ndimage.center_of_mass(subdata2)

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -12,11 +12,15 @@ def rebin(arr, new_shape):
     '''Rebin 2D array to given shape by averaging.
     Parameters
     ----------
-    arr: 2D array
-    new_shape: dimensions of new shape
+    arr : ndarray
+        2D array.
+    new_shape : tuple of int
+        Dimensions of new shape.
+
     Returns
-    ----------
-    newarr - Rebin 2D array arr to shape new_shape by averaging
+    --------
+    newarr : ndarray
+        Rebinned array.
     '''
     shape = (new_shape[0], arr.shape[0] // new_shape[0],
              new_shape[1], arr.shape[1] // new_shape[1])

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -77,12 +77,10 @@ def recenter(images, outputdir, doplot=False):
         ycntr = 1412
 
         # Recenter the image to 464, 1412 instead to match the WAS expectations
-        xcpsf = com2[0] + int((com1[0] - margin_left2)
-                              * imsize / size * 4 / size)\
-                        + int((com[0] - margin_left) * imsize / size)
-        ycpsf = com2[1] + int((com1[1] - margin_bottom2)
-                              * imsize / size * 4 / size) \
-                        + int((com[1] - margin_bottom) * imsize / size)
+        xcpsf = (com2[0] + int((com1[0] - margin_left2) * imsize / size * 4 / size)
+                 + int((com[0] - margin_left) * imsize / size))
+        ycpsf = (com2[1] + int((com1[1] - margin_bottom2) * imsize / size * 4 / size)
+                 + int((com[1] - margin_bottom) * imsize / size))
         offsetdata = np.roll(data, (xcntr - int(ycpsf),
                                     ycntr - int(xcpsf)),
                              axis=(1, 0))

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -46,15 +46,15 @@ def recenter(images, outputdir, doplot=False):
             margin_left = 1.5
             margin_right = 2.5
             margin_top = 2.5
-            margin_bottom = 1.5
+            margin_bttm = 1.5
             imsize = 2048
 
-            # Find the center of mass and cut a box around: we should see the whole
-            # PSF with about 1-2 PSF wide margins
+            # Find the center of mass and cut a box around: we should see the
+            # whole PSF with about 1-2 PSF wide margins
             com = ndimage.center_of_mass(rebindata)
             subdata = data[int((com[0] - margin_left) * imsize / size):
                            int((com[0] + margin_right) * imsize / size),
-                           int((com[1] - margin_bottom) * imsize / size):
+                           int((com[1] - margin_bttm) * imsize / size):
                            int((com[1] + margin_top) * imsize / size)]
 
             # Rebin again
@@ -63,17 +63,17 @@ def recenter(images, outputdir, doplot=False):
             # Remove background
             rebinsubdata -= np.median(rebinsubdata)
 
-            # Find the center of mass and cut a box around: should see the inside
-            # of the PSF
+            # Find the center of mass and cut a box around:
+            # should see the inside of the PSF
             com1 = ndimage.center_of_mass(rebinsubdata)
             margin_left2 = 0.5
             margin_right2 = 1.5
-            margin_bottom2 = 0.5
+            margin_bttm2 = 0.5
             margin_top2 = 1.5
-            subdata2 = subdata[int((com1[0] - margin_left2) * imsize / size * 4 / size):
-                               int((com1[0] + margin_right2) * imsize / size * 4 / size),
-                               int((com1[1] - margin_bottom2) * imsize / size * 4 / size):
-                               int((com1[1] + margin_top2) * imsize / size * 4 / size)]
+            subdata2 = subdata[int((com1[0]-margin_left2)*imsize/size*4/size):
+                               int((com1[0]+margin_right2)*imsize/size*4/size),
+                               int((com1[1]-margin_bttm2)*imsize/size*4/size):
+                               int((com1[1]+margin_top2)*imsize/size*4/size)]
 
             # Find the center of mass
             com2 = ndimage.center_of_mass(subdata2)
@@ -81,11 +81,12 @@ def recenter(images, outputdir, doplot=False):
             xcntr = 464
             ycntr = 1412
 
-            # Recenter the image to 464, 1412 instead to match the WAS expectations
-            xcpsf = (com2[0] + int((com1[0] - margin_left2) * imsize / size * 4 / size)
-                     + int((com[0] - margin_left) * imsize / size))
-            ycpsf = (com2[1] + int((com1[1] - margin_bottom2) * imsize / size * 4 / size)
-                     + int((com[1] - margin_bottom) * imsize / size))
+            # Recenter the image to 464, 1412 instead to match the WAS
+            # expectations
+            xcpsf = (com2[0]+int((com1[0]-margin_left2)*imsize/size*4/size)
+                     + int((com[0]-margin_left)*imsize/size))
+            ycpsf = (com2[1]+int((com1[1]-margin_bttm2)*imsize/size*4/size)
+                     + int((com[1]-margin_bttm)*imsize/size))
             offsetdata = np.roll(data, (xcntr - int(ycpsf),
                                         ycntr - int(xcpsf)),
                                  axis=(1, 0))
@@ -94,10 +95,10 @@ def recenter(images, outputdir, doplot=False):
             if abs(xcntr - ycpsf) > 10 or abs(ycntr - xcpsf) > 10:
                 # Do the same for the ERR and the DQ
                 hdul[2].data = np.roll(hdul[2].data,
-                                       (xcntr - int(ycpsf), ycntr - int(xcpsf)),
+                                       (xcntr-int(ycpsf), ycntr-int(xcpsf)),
                                        axis=(1, 0))
                 hdul[3].data = np.roll(hdul[3].data,
-                                       (xcntr - int(ycpsf), ycntr - int(xcpsf)),
+                                       (xcntr-int(ycpsf), ycntr-int(xcpsf)),
                                        axis=(1, 0))
                 hdul[1].data = offsetdata
                 filename = os.path.basename(im_fn).replace('.fits',

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -21,9 +21,9 @@ def recenter(images, outputdir, doplot=False):
         Show plots to the user via a popup.
 
     Returns
-    ----------
-    output_images: List
-        Output images that have been read and/or modified
+    -------
+    output_images : list
+        Output images that have been read and/or modified.
     '''
     output_images = []
     for im_fn in images:

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -9,7 +9,7 @@ __all__ = ['rebin', 'recenter']
 
 
 def rebin(arr, new_shape):
-    ''' rebin(arr, new_shape)
+    '''Rebin 2D array to given shape by averaging.
     Parameters
     ----------
     arr: 2D array

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -41,10 +41,13 @@ def recenter(images, outputdir, doplot=False):
         # Remove background
         rebindata -= np.median(rebindata)
 
-        # Find the center of mass and cut a box around: we should see the whole PSF with about 1-2 PSF wide margins
+        # Find the center of mass and cut a box around: we should see the whole
+        # PSF with about 1-2 PSF wide margins
         com = ndimage.center_of_mass(rebindata)
-        subdata = data[int((com[0] - 1.5) * 2048 / size):int((com[0] + 2.5) * 2048 / size),
-                    int((com[1] - 1.5) * 2048 / size):int((com[1] + 2.5) * 2048 / size)]
+        subdata = data[int((com[0] - 1.5) * 2048 / size):
+                       int((com[0] + 2.5) * 2048 / size),
+                       int((com[1] - 1.5) * 2048 / size):
+                       int((com[1] + 2.5) * 2048 / size)]
 
         # Rebin again
         rebinsubdata = rebin(subdata, [size, size])
@@ -52,34 +55,47 @@ def recenter(images, outputdir, doplot=False):
         # Remove background
         rebinsubdata -= np.median(rebinsubdata)
 
-        # Find the center of mass and cut a box around: we should see the inside of the PSF
+        # Find the center of mass and cut a box around: should see the inside
+        # of the PSF
         subdatacom = ndimage.center_of_mass(rebinsubdata)
-        subdata2 = subdata[int((subdatacom[0] - .5) * 2048 / size * 4 / size):int((subdatacom[0] + 1.5) * 2048 / size * 4 / size),
-                       int((subdatacom[1] - .5) * 2048 / size * 4 / size):int((subdatacom[1] + 1.5) * 2048 / size * 4 / size)]
+        subdata2 = subdata[int((subdatacom[0] - .5) * 2048 / size * 4 / size):
+                           int((subdatacom[0] + 1.5) * 2048 / size * 4 / size),
+                           int((subdatacom[1] - .5) * 2048 / size * 4 / size):
+                           int((subdatacom[1] + 1.5) * 2048 / size * 4 / size)]
 
         # Find the center of mass
         com2 = ndimage.center_of_mass(subdata2)
 
-        # "Recenter" the image to 464, 1412 instead to match the WAS expectations
-        xcpsf = com2[0] + int((subdatacom[0] - .5) * 2048 / size * 4 / size) + int((com[0] - 1.5) * 2048 / size)
-        ycpsf = com2[1] + int((subdatacom[1] - .5) * 2048 / size * 4 / size) + int((com[1] - 1.5) * 2048 / size)
-        offsetdata = np.roll(data, (464 - int(ycpsf), 1412 - int(xcpsf)), axis=(1, 0))
+        # Recenter the image to 464, 1412 instead to match the WAS expectations
+        xcpsf = com2[0] + int((subdatacom[0] - .5) * 2048 / size * 4 / size)\
+                        + int((com[0] - 1.5) * 2048 / size)
+        ycpsf = com2[1] + int((subdatacom[1] - .5) * 2048 / size * 4 / size) \
+                        + int((com[1] - 1.5) * 2048 / size)
+        offsetdata = np.roll(data, (464 - int(ycpsf), 1412 - int(xcpsf)),
+                             axis=(1, 0))
 
         # Save back image into file
         if abs(464 - ycpsf) > 10 or abs(1412 - xcpsf) > 10:
             # Do the same for the ERR and the DQ
-            hdul[2].data = np.roll(hdul[2].data, (464 - int(ycpsf), 1412 - int(xcpsf)), axis=(1, 0))
-            hdul[3].data = np.roll(hdul[3].data, (464 - int(ycpsf), 1412 - int(xcpsf)), axis=(1, 0))
+            hdul[2].data = np.roll(hdul[2].data,
+                                   (464 - int(ycpsf), 1412 - int(xcpsf)),
+                                   axis=(1, 0))
+            hdul[3].data = np.roll(hdul[3].data,
+                                   (464 - int(ycpsf), 1412 - int(xcpsf)),
+                                   axis=(1, 0))
             hdul[1].data = offsetdata
-            filename = os.path.basename(im_fn).replace('.fits', '_recenter.fits')
+            filename = os.path.basename(im_fn).replace('.fits',
+                                                       '_recenter.fits')
             hdul.writeto(os.path.join(outputdir, filename), overwrite=True)
             output_images.append(os.path.join(outputdir, filename))
-        else :
+        else:
             output_images.append(im_fn)
 
         # Plot
 
-        fig, ((ax1, ax2), (ax3, ax4), (ax5, ax6)) = plt.subplots(3, 2, figsize=(12, 9))
+        fig, ((ax1, ax2),
+              (ax3, ax4),
+              (ax5, ax6)) = plt.subplots(3, 2, figsize=(12, 9))
         fig.tight_layout(pad=.3)
         ax1.imshow(data, origin='lower')
         ax2.imshow(rebindata, origin='lower')
@@ -97,5 +113,5 @@ def recenter(images, outputdir, doplot=False):
         if doplot:
             plt.show()
         else:
-            plt.savefig(os.path.join(outputdir,'plot.png'))
+            plt.savefig(os.path.join(outputdir, 'plot.png'))
     return output_images

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -1,33 +1,12 @@
 ''' Module to recenter images '''
 import os
 from astropy.io import fits
+from astropy.nddata import block_reduce
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import ndimage
 
-__all__ = ['rebin', 'recenter']
-
-
-def rebin(arr, new_shape):
-    '''Rebin 2D array to given shape by averaging.
-    Parameters
-    ----------
-    arr : ndarray
-        2D array.
-    new_shape : tuple of int
-        Dimensions of new shape.
-
-    Returns
-    --------
-    newarr : ndarray
-        Rebinned array.
-    '''
-    shape = (new_shape[0], arr.shape[0] // new_shape[0],
-             new_shape[1], arr.shape[1] // new_shape[1])
-    newarr = np.nanmedian(np.nanmedian(arr.reshape(shape), axis=-1), axis=1)
-
-    return newarr
-
+__all__ = ['recenter']
 
 def recenter(images, outputdir, doplot=False):
     ''' Recenter images based on NIRCam XY (464,1412) if offset > 10px
@@ -53,7 +32,7 @@ def recenter(images, outputdir, doplot=False):
 
         # Rebin image with very big pixels to find the approximate location
         size = 32
-        rebindata = rebin(data, [size, size])
+        rebindata = block_reduce(data, block_size=64, func=np.median)
 
         # Remove background
         rebindata -= np.median(rebindata)
@@ -73,7 +52,7 @@ def recenter(images, outputdir, doplot=False):
                        int((com[1] + margin_top) * imsize / size)]
 
         # Rebin again
-        rebinsubdata = rebin(subdata, [size, size])
+        rebinsubdata = block_reduce(subdata, block_size=8, func=np.median)
 
         # Remove background
         rebinsubdata -= np.median(rebinsubdata)

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -1,4 +1,6 @@
 ''' Module to recenter images '''
+
+# STDLIB
 import os
 from astropy.io import fits
 from astropy.nddata import block_reduce
@@ -10,7 +12,8 @@ __all__ = ['recenter']
 
 
 def recenter(images, outputdir, doplot=False):
-    '''Recenter images based on NIRCam XY (464,1412) if offset > 10px
+    """Recenter images based on NIRCam XY (464,1412) if offset > 10px
+
     Parameters
     ----------
     images : list
@@ -24,83 +27,85 @@ def recenter(images, outputdir, doplot=False):
     -------
     output_images : list
         Output images that have been read and/or modified.
-    '''
+
+    """
+
     output_images = []
     for im_fn in images:
         # Open fits
-        hdul = fits.open(im_fn)
-        data = hdul[1].data
+        with fits.open(im_fn) as hdul:
+            data = hdul[1].data
 
-        # Rebin image with very big pixels to find the approximate location
-        size = 32
-        rebindata = block_reduce(data, block_size=64, func=np.median)
+            # Rebin image with very big pixels to find the approximate location
+            size = 32
+            rebindata = block_reduce(data, block_size=64, func=np.median)
 
-        # Remove background
-        rebindata -= np.median(rebindata)
+            # Remove background
+            rebindata -= np.median(rebindata)
 
-        margin_left = 1.5
-        margin_right = 2.5
-        margin_top = 2.5
-        margin_bottom = 1.5
-        imsize = 2048
+            margin_left = 1.5
+            margin_right = 2.5
+            margin_top = 2.5
+            margin_bottom = 1.5
+            imsize = 2048
 
-        # Find the center of mass and cut a box around: we should see the whole
-        # PSF with about 1-2 PSF wide margins
-        com = ndimage.center_of_mass(rebindata)
-        subdata = data[int((com[0] - margin_left) * imsize / size):
-                       int((com[0] + margin_right) * imsize / size),
-                       int((com[1] - margin_bottom) * imsize / size):
-                       int((com[1] + margin_top) * imsize / size)]
+            # Find the center of mass and cut a box around: we should see the whole
+            # PSF with about 1-2 PSF wide margins
+            com = ndimage.center_of_mass(rebindata)
+            subdata = data[int((com[0] - margin_left) * imsize / size):
+                           int((com[0] + margin_right) * imsize / size),
+                           int((com[1] - margin_bottom) * imsize / size):
+                           int((com[1] + margin_top) * imsize / size)]
 
-        # Rebin again
-        rebinsubdata = block_reduce(subdata, block_size=8, func=np.median)
+            # Rebin again
+            rebinsubdata = block_reduce(subdata, block_size=8, func=np.median)
 
-        # Remove background
-        rebinsubdata -= np.median(rebinsubdata)
+            # Remove background
+            rebinsubdata -= np.median(rebinsubdata)
 
-        # Find the center of mass and cut a box around: should see the inside
-        # of the PSF
-        com1 = ndimage.center_of_mass(rebinsubdata)
-        margin_left2 = 0.5
-        margin_right2 = 1.5
-        margin_bottom2 = 0.5
-        margin_top2 = 1.5
-        subdata2 = subdata[int((com1[0] - margin_left2) * imsize / size * 4 / size):
-                           int((com1[0] + margin_right2) * imsize / size * 4 / size),
-                           int((com1[1] - margin_bottom2) * imsize / size * 4 / size):
-                           int((com1[1] + margin_top2) * imsize / size * 4 / size)]
+            # Find the center of mass and cut a box around: should see the inside
+            # of the PSF
+            com1 = ndimage.center_of_mass(rebinsubdata)
+            margin_left2 = 0.5
+            margin_right2 = 1.5
+            margin_bottom2 = 0.5
+            margin_top2 = 1.5
+            subdata2 = subdata[int((com1[0] - margin_left2) * imsize / size * 4 / size):
+                               int((com1[0] + margin_right2) * imsize / size * 4 / size),
+                               int((com1[1] - margin_bottom2) * imsize / size * 4 / size):
+                               int((com1[1] + margin_top2) * imsize / size * 4 / size)]
 
-        # Find the center of mass
-        com2 = ndimage.center_of_mass(subdata2)
+            # Find the center of mass
+            com2 = ndimage.center_of_mass(subdata2)
 
-        xcntr = 464
-        ycntr = 1412
+            xcntr = 464
+            ycntr = 1412
 
-        # Recenter the image to 464, 1412 instead to match the WAS expectations
-        xcpsf = (com2[0] + int((com1[0] - margin_left2) * imsize / size * 4 / size)
-                 + int((com[0] - margin_left) * imsize / size))
-        ycpsf = (com2[1] + int((com1[1] - margin_bottom2) * imsize / size * 4 / size)
-                 + int((com[1] - margin_bottom) * imsize / size))
-        offsetdata = np.roll(data, (xcntr - int(ycpsf),
-                                    ycntr - int(xcpsf)),
-                             axis=(1, 0))
+            # Recenter the image to 464, 1412 instead to match the WAS expectations
+            xcpsf = (com2[0] + int((com1[0] - margin_left2) * imsize / size * 4 / size)
+                     + int((com[0] - margin_left) * imsize / size))
+            ycpsf = (com2[1] + int((com1[1] - margin_bottom2) * imsize / size * 4 / size)
+                     + int((com[1] - margin_bottom) * imsize / size))
+            offsetdata = np.roll(data, (xcntr - int(ycpsf),
+                                        ycntr - int(xcpsf)),
+                                 axis=(1, 0))
 
-        # Save back image into file
-        if abs(xcntr - ycpsf) > 10 or abs(ycntr - xcpsf) > 10:
-            # Do the same for the ERR and the DQ
-            hdul[2].data = np.roll(hdul[2].data,
-                                   (xcntr - int(ycpsf), ycntr - int(xcpsf)),
-                                   axis=(1, 0))
-            hdul[3].data = np.roll(hdul[3].data,
-                                   (xcntr - int(ycpsf), ycntr - int(xcpsf)),
-                                   axis=(1, 0))
-            hdul[1].data = offsetdata
-            filename = os.path.basename(im_fn).replace('.fits',
-                                                       '_recenter.fits')
-            hdul.writeto(os.path.join(outputdir, filename), overwrite=True)
-            output_images.append(os.path.join(outputdir, filename))
-        else:
-            output_images.append(im_fn)
+            # Save back image into file
+            if abs(xcntr - ycpsf) > 10 or abs(ycntr - xcpsf) > 10:
+                # Do the same for the ERR and the DQ
+                hdul[2].data = np.roll(hdul[2].data,
+                                       (xcntr - int(ycpsf), ycntr - int(xcpsf)),
+                                       axis=(1, 0))
+                hdul[3].data = np.roll(hdul[3].data,
+                                       (xcntr - int(ycpsf), ycntr - int(xcpsf)),
+                                       axis=(1, 0))
+                hdul[1].data = offsetdata
+                filename = os.path.basename(im_fn).replace('.fits',
+                                                           '_recenter.fits')
+                hdul.writeto(os.path.join(outputdir, filename), overwrite=True)
+                output_images.append(os.path.join(outputdir, filename))
+            else:
+                output_images.append(im_fn)
 
         # Plot
 

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -5,6 +5,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy import ndimage
 
+__all__ = ['rebin', 'recenter']
+
 
 def rebin(arr, new_shape):
     ''' rebin(arr, new_shape)

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -13,12 +13,12 @@ def recenter(images, outputdir, doplot=False):
     '''Recenter images based on NIRCam XY (464,1412) if offset > 10px
     Parameters
     ----------
-    images: List
-        List of input images to analyze
-    outputdir: String
-        Working directory where QUIP will write the files to
-    doplot: boolean
-        Show plots to the user via a popup
+    images : list
+        List of input images to analyze.
+    outputdir : str
+        Working directory where QUIP will write the files to.
+    doplot : bool
+        Show plots to the user via a popup.
 
     Returns
     ----------

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -8,6 +8,7 @@ from scipy import ndimage
 
 __all__ = ['recenter']
 
+
 def recenter(images, outputdir, doplot=False):
     ''' Recenter images based on NIRCam XY (464,1412) if offset > 10px
     Parameters

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -30,16 +30,21 @@ def rebin(arr, new_shape):
 
 
 def recenter(images, outputdir, doplot=False):
-    ''' recenter(images, outputdir, doplot=False)
-   Parameters
-   ----------
-   images:
-   outputdir: dimensions of new shape
-   doplot: boolean
-   Returns
-   ----------
-   newarr - Rebin 2D array arr to shape new_shape by averaging
-   '''
+    ''' Recenter images based on NIRCam XY (464,1412) if offset > 10px
+    Parameters
+    ----------
+    images: List
+        List of input images to analyze
+    outputdir: String
+        Working directory where QUIP will write the files to
+    doplot: boolean
+        Show plots to the user via a popup
+
+    Returns
+    ----------
+    output_images: List
+        Output images that have been read and/or modified
+    '''
     output_images = []
     for im_fn in images:
         # Open fits

--- a/wss_tools/utils/recenter.py
+++ b/wss_tools/utils/recenter.py
@@ -1,0 +1,101 @@
+''' Module to recenter images '''
+import os
+from astropy.io import fits
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import ndimage
+
+
+def rebin(arr, new_shape):
+    '''
+    Rebin 2D array arr to shape new_shape by averaging
+    :param arr:
+    :param new_shape:
+    :return: newarr - new array
+    '''
+    shape = (new_shape[0], arr.shape[0] // new_shape[0],
+             new_shape[1], arr.shape[1] // new_shape[1])
+    newarr = np.nanmedian(np.nanmedian(arr.reshape(shape), axis=-1), axis=1)
+
+    return newarr
+
+
+def recenter(images, outputdir, doplot=False):
+    '''
+    Recenter images to NRCA3 FP3 (464, 1412)
+    :param images:
+    :param outputdir:
+    :param doplot:
+    :return: List of output_images that have been recentered
+    '''
+    output_images = []
+    for im_fn in images:
+        # Open fits
+        hdul = fits.open(im_fn)
+        data = hdul[1].data
+
+        # Rebin image with very big pixels to find the approximate location
+        size = 32
+        rebindata = rebin(data, [size, size])
+
+        # Remove background
+        rebindata -= np.median(rebindata)
+
+        # Find the center of mass and cut a box around: we should see the whole PSF with about 1-2 PSF wide margins
+        com = ndimage.center_of_mass(rebindata)
+        subdata = data[int((com[0] - 1.5) * 2048 / size):int((com[0] + 2.5) * 2048 / size),
+                    int((com[1] - 1.5) * 2048 / size):int((com[1] + 2.5) * 2048 / size)]
+
+        # Rebin again
+        rebinsubdata = rebin(subdata, [size, size])
+
+        # Remove background
+        rebinsubdata -= np.median(rebinsubdata)
+
+        # Find the center of mass and cut a box around: we should see the inside of the PSF
+        subdatacom = ndimage.center_of_mass(rebinsubdata)
+        subdata2 = subdata[int((subdatacom[0] - .5) * 2048 / size * 4 / size):int((subdatacom[0] + 1.5) * 2048 / size * 4 / size),
+                       int((subdatacom[1] - .5) * 2048 / size * 4 / size):int((subdatacom[1] + 1.5) * 2048 / size * 4 / size)]
+
+        # Find the center of mass
+        com2 = ndimage.center_of_mass(subdata2)
+
+        # "Recenter" the image to 464, 1412 instead to match the WAS expectations
+        xcpsf = com2[0] + int((subdatacom[0] - .5) * 2048 / size * 4 / size) + int((com[0] - 1.5) * 2048 / size)
+        ycpsf = com2[1] + int((subdatacom[1] - .5) * 2048 / size * 4 / size) + int((com[1] - 1.5) * 2048 / size)
+        offsetdata = np.roll(data, (464 - int(ycpsf), 1412 - int(xcpsf)), axis=(1, 0))
+
+        # Save back image into file
+        if abs(464 - ycpsf) > 10 or abs(1412 - xcpsf) > 10:
+            # Do the same for the ERR and the DQ
+            hdul[2].data = np.roll(hdul[2].data, (464 - int(ycpsf), 1412 - int(xcpsf)), axis=(1, 0))
+            hdul[3].data = np.roll(hdul[3].data, (464 - int(ycpsf), 1412 - int(xcpsf)), axis=(1, 0))
+            hdul[1].data = offsetdata
+            filename = os.path.basename(im_fn).replace('.fits', '_recenter.fits')
+            hdul.writeto(os.path.join(outputdir, filename), overwrite=True)
+            output_images.append(os.path.join(outputdir, filename))
+        else :
+            output_images.append(im_fn)
+
+        # Plot
+
+        fig, ((ax1, ax2), (ax3, ax4), (ax5, ax6)) = plt.subplots(3, 2, figsize=(12, 9))
+        fig.tight_layout(pad=.3)
+        ax1.imshow(data, origin='lower')
+        ax2.imshow(rebindata, origin='lower')
+
+        ax3.imshow(subdata, origin='lower')
+        ax4.imshow(rebinsubdata, origin='lower')
+
+        ax5.imshow(subdata2, origin='lower')
+        ax5.plot([com2[1], com2[1]], [0, 2048/size*4/size*2-1], 'r')
+        ax5.plot([0, 2048/size*4/size*2-1], [com2[0], com2[0]], 'r')
+
+        ax6.imshow(offsetdata, origin='lower')
+        ax6.plot([464, 464], [0, 2047], 'r')
+        ax6.plot([0, 2047], [1412, 1412], 'r')
+        if doplot:
+            plt.show()
+        else:
+            plt.savefig(os.path.join(outputdir,'plot.png'))
+    return output_images


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/wss_tools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
Updates to QUIP to support routine wavefront maintenance. Some of the routine observations have shown that we may need to recenter the image since the WAS is particular about the centroid of the image to fall on a XY of NRCA3 FP3 (464, 1412). So now if QUIP is run with WAVEFRONT_MAINTENANCE operation then it will invoke the recenter function to do some batch processing and update the quip_out.xml if the centroid was offset by 10px in X or Y.
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #93 
