### PR TITLE
MNT: Compatibility with Ginga v4

### DIFF
--- a/wss_tools/quip/plugins/AboutQUIP.py
+++ b/wss_tools/quip/plugins/AboutQUIP.py
@@ -50,7 +50,7 @@ class AboutQUIP(GlobalPlugin):
         vbox.set_spacing(2)
 
         # Take a text widget to show version info
-        msgFont = self.fv.getFont('sansFont', 12)
+        msgFont = self.fv.get_font('sansFont', 12)
         tw = Widgets.TextArea(wrap=True, editable=False)
         tw.set_font(msgFont)
         tw.set_text(self.info_string())


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/wss_tools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to address compatibility issues with upcoming Ginga v4 release. This is a major release and includes some breaking changes.

Since I am handing this repository to @kulpster85 , he might have to take over this PR and finish it.

### Blocked by

- https://github.com/spacetelescope/stginga/issues/227

### TODO

- [ ] Find other incompatibilities and add their fixes here. Go through examples in https://wss-tools.readthedocs.io/en/latest/wss_tools/quip/index.html#using-quip and try out the custom plugins.
- [ ] Make sure these fixes are backward-compatible with older Ginga that QUIP supports (e.g., you might need to check for Ginga version before picking which code to use). Alternatively, you can also bump minversion of supported Ginga in `setup.cfg` and not have to worry about backward compatibility.

If you decide to not ever use Ginga v4 (i.e., pin your maxversion to v3, then there is no need for this PR but you also will not get any new Ginga fixes or features).